### PR TITLE
Added Workoders, got rid of stub in ApplicationViews

### DIFF
--- a/Controllers/WorkOrderController.cs
+++ b/Controllers/WorkOrderController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using BiancasBikes.Data;
+using BiancasBikes.Models;
+using BiancasBikes.Models.DTOs;
+
+
+namespace BiancasBikes.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WorkOrderController : ControllerBase
+{
+    private BiancasBikesDbContext _dbContext;
+
+    public WorkOrderController(BiancasBikesDbContext context)
+    {
+        _dbContext = context;
+    }
+
+    [HttpGet("incomplete")]
+    [Authorize]
+    public IActionResult GetIncompleteWorkOrders()
+    {
+        return Ok(_dbContext.WorkOrders
+        .Include(wo => wo.Bike)
+        .ThenInclude(b => b.Owner)
+        .Include(wo => wo.Bike)
+        .ThenInclude(b => b.BikeType)
+        .Include(wo => wo.UserProfile)
+        .Where(wo => wo.DateCompleted == null)
+        .OrderBy(wo => wo.DateInitiated)
+        .ThenByDescending(wo => wo.UserProfileId == null).ToList());
+    }
+}

--- a/client/src/components/ApplicationViews.jsx
+++ b/client/src/components/ApplicationViews.jsx
@@ -3,6 +3,8 @@ import Bikes from "./bikes/Bikes";
 import { AuthorizedRoute } from "./auth/AuthorizedRoute";
 import Login from "./auth/Login";
 import Register from "./auth/Register";
+import {WorkOrderList} from "./WorkOrderList";
+
 
 export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
   return (
@@ -25,18 +27,18 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
           }
         />
         <Route
-          path="workorders"
-          element={
-            <AuthorizedRoute loggedInUser={loggedInUser}>
-              <p>Work Orders</p>
-            </AuthorizedRoute>
-          }
-        />
-        <Route
           path="employees"
           element={
             <AuthorizedRoute roles={["Admin"]} loggedInUser={loggedInUser}>
               <p>Employees</p>
+            </AuthorizedRoute>
+          }
+        />
+        <Route
+          path="workorders"
+          element={
+            <AuthorizedRoute loggedInUser={loggedInUser}>
+              <WorkOrderList />
             </AuthorizedRoute>
           }
         />

--- a/client/src/components/WorkOrderList.jsx
+++ b/client/src/components/WorkOrderList.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { Table } from "reactstrap";
+import { getIncompleteWorkOrders } from "../managers/workOrderManager";
+
+
+
+export const WorkOrderList = ({ loggedInUser }) => {
+  const [workOrders, setWorkOrders] = useState([]);
+
+  console.log("useEffect")
+  
+useEffect(() => {
+  getIncompleteWorkOrders().then((data) => {
+    console.log("Fetched work orders:", data);
+    if (!Array.isArray(data)) {
+      console.error("Expected array but got:", data);
+    }
+    setWorkOrders(data);
+  });
+}, []);
+
+
+
+  return (
+    <>
+      <h2>Open Work Orders</h2>
+      <Table>
+        <thead>
+          <tr>
+            <th>Owner</th>
+            <th>Brand</th>
+            <th>Color</th>
+            <th>Description</th>
+            <th>DateSubmitted</th>
+            <th>Mechanic</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {workOrders.map((wo) => (
+            <tr key={wo.id}>
+              <th scope="row">{wo.bike.owner.name}</th>
+              <td>{wo.bike.brand}</td>
+              <td>{wo.bike.color}</td>
+              <td>{wo.description}</td>
+              <td>{new Date(wo.dateInitiated).toLocaleDateString()}</td>
+              <td>
+                {wo.userProfile
+                  ? `${wo.userProfile.firstName} ${wo.userProfile.lastName}`
+                  : "unassigned"}
+              </td>
+              <td></td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </>
+  );
+}

--- a/client/src/managers/bikeManager.js
+++ b/client/src/managers/bikeManager.js
@@ -11,3 +11,4 @@ export const getBikeById = (id) => {
 export const getBikesInShopCount = () => {
   return fetch(`${apiUrl}/inventory`).then((res) => res.json());
 };
+

--- a/client/src/managers/workOrderManager.js
+++ b/client/src/managers/workOrderManager.js
@@ -1,0 +1,11 @@
+const _apiUrl = "/api/workorder";
+
+export const getIncompleteWorkOrders = () => {
+return fetch(_apiUrl + "/incomplete", {
+  credentials: "include"
+}).then((res) => {
+  console.log("Fetch status:", res.status);
+  return res.json();
+});
+
+};


### PR DESCRIPTION
# Add Work Order Listing Feature

## Summary

This PR introduces the ability to view open work orders in the Bianca's Bike Shop application.

## Changes Made

- Created `WorkOrderController.cs` to serve incomplete work orders via `/api/workorder/incomplete`
- Added `WorkOrderList.jsx` component to render work orders in a table
- Introduced `workOrderManager.js` for API interaction with backend
- Updated `ApplicationViews.jsx` to wire `/workorders` route correctly
- Removed legacy/stubbed route that was overriding the proper component

## Notes

- Data loads only for authenticated users via cookie
- Backend joins include `Bike`, `Owner`, `BikeType`, and `UserProfile`
- Frontend shows `brand`, `color`, `description`, assigned `mechanic`, and `dateSubmitted`

✅ Verified UI loads and reflects seeded work orders  
🔐 Protected by `[Authorize]` and uses proper session handling

---