### PR TITLE
Added CreateWorkOrder

### DIFF
--- a/Controllers/WorkOrderController.cs
+++ b/Controllers/WorkOrderController.cs
@@ -24,13 +24,24 @@ public class WorkOrderController : ControllerBase
     public IActionResult GetIncompleteWorkOrders()
     {
         return Ok(_dbContext.WorkOrders
-        .Include(wo => wo.Bike)
-        .ThenInclude(b => b.Owner)
-        .Include(wo => wo.Bike)
-        .ThenInclude(b => b.BikeType)
-        .Include(wo => wo.UserProfile)
-        .Where(wo => wo.DateCompleted == null)
-        .OrderBy(wo => wo.DateInitiated)
-        .ThenByDescending(wo => wo.UserProfileId == null).ToList());
+            .Include(wo => wo.Bike)
+                .ThenInclude(b => b.Owner)
+            .Include(wo => wo.Bike)
+                .ThenInclude(b => b.BikeType)
+            .Include(wo => wo.UserProfile)
+            .Where(wo => wo.DateCompleted == null)
+            .OrderBy(wo => wo.DateInitiated)
+            .ThenByDescending(wo => wo.UserProfileId == null)
+            .ToList());
+    }
+
+    [HttpPost]
+    [Authorize]
+    public IActionResult CreateWorkOrder(WorkOrder workOrder)
+    {
+        workOrder.DateInitiated = DateTime.Now;
+        _dbContext.WorkOrders.Add(workOrder);
+        _dbContext.SaveChanges();
+        return Created($"/api/workorder/{workOrder.Id}", workOrder);
     }
 }

--- a/client/src/components/ApplicationViews.jsx
+++ b/client/src/components/ApplicationViews.jsx
@@ -3,7 +3,9 @@ import Bikes from "./bikes/Bikes";
 import { AuthorizedRoute } from "./auth/AuthorizedRoute";
 import Login from "./auth/Login";
 import Register from "./auth/Register";
-import {WorkOrderList} from "./WorkOrderList";
+import { WorkOrderList } from "./workorders/WorkOrderList";
+import CreateWorkOrder from "./workorders/CreateWorkOrder";
+
 
 
 export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
@@ -34,14 +36,24 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
             </AuthorizedRoute>
           }
         />
-        <Route
-          path="workorders"
-          element={
-            <AuthorizedRoute loggedInUser={loggedInUser}>
-              <WorkOrderList />
-            </AuthorizedRoute>
-          }
-        />
+        <Route path="workorders">
+          <Route
+            index
+            element={
+              <AuthorizedRoute loggedInUser={loggedInUser}>
+                <WorkOrderList />
+              </AuthorizedRoute>
+            }
+          />
+          <Route
+            path="create"
+            element={
+              <AuthorizedRoute loggedInUser={loggedInUser}>
+                <CreateWorkOrder />
+              </AuthorizedRoute>
+            }
+          />
+        </Route>
         <Route
           path="login"
           element={<Login setLoggedInUser={setLoggedInUser} />}

--- a/client/src/components/workorders/CreateWorkOrder.jsx
+++ b/client/src/components/workorders/CreateWorkOrder.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getBikes } from "../../managers/bikeManager";
+import { Button, Form, FormGroup, Input, Label } from "reactstrap";
+import { createWorkOrder } from "../../managers/workOrderManager";
+
+export default function CreateWorkOrder({ loggedInUser }) {
+  const [description, setDescription] = useState("");
+  const [bikeId, setBikeId] = useState(0);
+  const [bikes, setBikes] = useState([]);
+  const navigate = useNavigate();
+
+  
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const newWorkOrder = {
+      bikeId,
+      description,
+    };
+
+    console.log(
+      `new work order submitted: ${newWorkOrder.description}, bikeId: ${newWorkOrder.bikeId}`
+    );
+
+    createWorkOrder(newWorkOrder).then(() => {
+      navigate("/workorders");
+    });
+  };
+
+  useEffect(() => {
+    getBikes().then(setBikes);
+  }, []);
+
+  return (
+    <>
+      <h2>Open a Work Order</h2>
+      <Form>
+        <FormGroup>
+          <Label>Description</Label>
+          <Input
+            type="text"
+            value={description}
+            onChange={(e) => {
+              setDescription(e.target.value);
+            }}
+          />
+        </FormGroup>
+        <FormGroup>
+          <Label>Bike</Label>
+          <Input
+            type="select"
+            value={bikeId}
+            onChange={(e) => {
+              setBikeId(parseInt(e.target.value));
+            }}
+          >
+            <option value={0}>Choose a Bike</option>
+            {bikes.map((b) => (
+              <option
+                key={b.id}
+                value={b.id}
+              >{`${b.owner.name} - ${b.brand} - ${b.color}`}</option>
+            ))}
+          </Input>
+        </FormGroup>
+        <Button onClick={handleSubmit} color="primary">
+          Submit
+        </Button>
+      </Form>
+    </>
+  );
+}

--- a/client/src/components/workorders/WorkOrderList.jsx
+++ b/client/src/components/workorders/WorkOrderList.jsx
@@ -1,29 +1,24 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Table } from "reactstrap";
-import { getIncompleteWorkOrders } from "../managers/workOrderManager";
-
-
+import { getIncompleteWorkOrders } from "../../managers/workOrderManager";
 
 export const WorkOrderList = ({ loggedInUser }) => {
   const [workOrders, setWorkOrders] = useState([]);
 
-  console.log("useEffect")
-  
-useEffect(() => {
-  getIncompleteWorkOrders().then((data) => {
-    console.log("Fetched work orders:", data);
-    if (!Array.isArray(data)) {
-      console.error("Expected array but got:", data);
-    }
-    setWorkOrders(data);
-  });
-}, []);
-
-
+  useEffect(() => {
+    getIncompleteWorkOrders().then((data) => {
+      if (!Array.isArray(data)) {
+        console.error("Expected array but got:", data);
+      }
+      setWorkOrders(data);
+    });
+  }, []);
 
   return (
     <>
       <h2>Open Work Orders</h2>
+      <Link to="/workorders/create">New Work Order</Link>
       <Table>
         <thead>
           <tr>
@@ -56,4 +51,4 @@ useEffect(() => {
       </Table>
     </>
   );
-}
+};

--- a/client/src/managers/workOrderManager.js
+++ b/client/src/managers/workOrderManager.js
@@ -9,3 +9,13 @@ return fetch(_apiUrl + "/incomplete", {
 });
 
 };
+
+export const createWorkOrder = (workOrder) => {
+  return fetch(_apiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(workOrder),
+  }).then((res) => res.json);
+};


### PR DESCRIPTION
# Add Work Order Creation Feature

## Summary
This PR implements the ability to create a new work order in Bianca's Bike Shop. Users can now navigate to a form, select a bike, provide a description, and submit a new work order.

## What's Included

### Frontend
- Created `CreateWorkOrder.jsx` form component inside `components/workorders/`
- Updated `ApplicationViews.jsx` to nest two routes under `workorders/`
  - `/workorders` shows the list
  - `/workorders/create` shows the form
- Moved `WorkOrderList.jsx` into `workorders/` subfolder
- Hooked up `createWorkOrder()` API function from `workOrderManager.js`
- Navigates to `/workorders` after successful form submission

### Backend
- Added `[HttpPost]` endpoint to `WorkOrderController.cs` to handle new work order creation
  - Automatically sets `DateInitiated` to `DateTime.Now`
  - Returns `201 Created` on success

## How to Test
1. Login
2. Navigate to `/workorders/create`
3. Fill out the form (choose a bike, enter a description)
4. Submit
5. You should be redirected to `/workorders`, and see the new entry listed

## Notes
- No validation yet (future enhancement)
- `bikeId` is sent as an integer, make sure `0` is not valid in DB
- No toast or alert on success — currently a silent UX flow

---