### PR TITLE
Added New endpoints to assign and delete workorders

### DIFF
--- a/Controllers/WorkOrderController.cs
+++ b/Controllers/WorkOrderController.cs
@@ -44,4 +44,53 @@ public class WorkOrderController : ControllerBase
         _dbContext.SaveChanges();
         return Created($"/api/workorder/{workOrder.Id}", workOrder);
     }
+
+    [HttpPut("{id}/complete")]
+    [Authorize]
+    public IActionResult CompleteWorkOrder(int id)
+    {
+        var workOrder = _dbContext.WorkOrders.SingleOrDefault(wo => wo.Id == id);
+        if (workOrder == null) return NotFound();
+
+        workOrder.DateCompleted = DateTime.Now;
+        _dbContext.SaveChanges();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public IActionResult Delete(int id)
+    {
+        var workOrder = _dbContext.WorkOrders.SingleOrDefault(wo => wo.Id == id);
+        if (workOrder == null) return NotFound();
+
+        _dbContext.WorkOrders.Remove(workOrder);
+        _dbContext.SaveChanges();
+        return NoContent();
+    }
+
+    [HttpPut("{id}")]
+    [Authorize]
+    public IActionResult UpdateWorkOrder(WorkOrder workOrder, int id)
+    {
+        WorkOrder workOrderToUpdate = _dbContext.WorkOrders.SingleOrDefault(wo => wo.Id == id);
+        if (workOrderToUpdate == null)
+        {
+            return NotFound();
+        }
+        else if (id != workOrder.Id)
+        {
+            return BadRequest();
+        }
+
+        // Only allow these fields to be updated
+        workOrderToUpdate.Description = workOrder.Description;
+        workOrderToUpdate.UserProfileId = workOrder.UserProfileId;
+        workOrderToUpdate.BikeId = workOrder.BikeId;
+
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
+
 }

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -1,0 +1,5 @@
+const _apiUrl = "/api/userprofile";
+
+export const getUserProfiles = () => {
+  return fetch(_apiUrl).then((res) => res.json());
+};

--- a/client/src/managers/workOrderManager.js
+++ b/client/src/managers/workOrderManager.js
@@ -1,13 +1,12 @@
 const _apiUrl = "/api/workorder";
 
 export const getIncompleteWorkOrders = () => {
-return fetch(_apiUrl + "/incomplete", {
-  credentials: "include"
-}).then((res) => {
-  console.log("Fetch status:", res.status);
-  return res.json();
-});
-
+  return fetch(_apiUrl + "/incomplete", {
+    credentials: "include",
+  }).then((res) => {
+    console.log("Fetch status:", res.status);
+    return res.json();
+  });
 };
 
 export const createWorkOrder = (workOrder) => {
@@ -17,5 +16,21 @@ export const createWorkOrder = (workOrder) => {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(workOrder),
-  }).then((res) => res.json);
+  }).then((res) => res.json()); 
 };
+
+export const updateWorkOrder = (workOrder) => {
+  return fetch(`${_apiUrl}/${workOrder.id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(workOrder),
+  });
+};
+
+export const completeWorkOrder = (id) =>
+  fetch(`${_apiUrl}/${id}/complete`, { method: "PUT" });
+
+export const deleteWorkOrder = (id) =>
+  fetch(`${_apiUrl}/${id}`, { method: "DELETE" });


### PR DESCRIPTION
# PR: Assign and Delete Work Orders

## Summary

This PR adds functionality for assigning mechanics to work orders and deleting work orders via the UI and backend. It includes full implementation of the supporting endpoints and updates the WorkOrderList UI to support mechanic assignment, completion, and deletion.

---

## Changes Made

### Backend

- **`WorkOrderController.cs`**
  - Added `[HttpPut("{id}")]` endpoint to handle updates to work orders (used for assigning mechanics).
  - Added endpoints for `complete` and `delete`.

---

### Frontend

- **`WorkOrderList.jsx`**
  - Replaced static mechanic display with a `<select>` dropdown for assigning.
  - Added "Mark as Complete" and "Delete" buttons in the Actions column.
  - Uses `structuredClone()` to safely update work orders.
  - Loads both `workOrders` and `mechanics` on component mount.

- **`workOrderManager.js`**
  - Added `updateWorkOrder(workOrder)` for updating a work order.
  - Reused `completeWorkOrder(id)` and `deleteWorkOrder(id)` for completion and deletion actions.

- **`userProfileManager.js`**
  - Created and added new file for fetching all mechanics (via `/api/userprofile`).

---

## To Test

1. Go to `/workorders`
2. Select a mechanic from the dropdown — ensure the work order updates.
3. Click “Mark as Complete” — item should be removed from list.
4. Click “Delete” — item should be removed from list.
5. Monitor network tab or server logs to confirm correct API calls are triggered.

---